### PR TITLE
Docker configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.6-alpine
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PYTHONPATH="/usr/src/app"
+EXPOSE 8080
+
+CMD [ "python", "-m", "rt_playground.dashboard" ]

--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ Local setup
     honcho start
    ```
 6. rt-dashboard should be accessible at http://localhost:8080
+
+Docker setup
+------------
+1. Start all containers
+    ```
+    docker-compose up
+    ```
+2. rt-dashboard should be accessible at http://localhost:8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,40 @@
+version: "3.2"
+services:
+
+  redis:
+    image: redis:6-alpine
+
+  web:
+    image: rt-playground
+    build: .
+    depends_on:
+      - redis
+    volumes:
+      - .:/usr/src/app
+    env_file:
+      - .env
+    environment:
+      REDIS_URL: redis://redis:6379
+      HOST: 0.0.0.0
+    ports:
+      - "8080:8080"
+
+  worker:
+    image: rt-playground
+    command: redis_tasks worker
+    depends_on:
+      - redis
+    env_file:
+      - .env
+    environment:
+      REDIS_URL: redis://redis:6379
+
+  scheduler:
+    image: rt-playground
+    command: redis_tasks scheduler
+    depends_on:
+      - redis
+    env_file:
+      - .env
+    environment:
+      REDIS_URL: redis://redis:6379


### PR DESCRIPTION
Had to base on #1 due to missing configuration options.

Builds a single `rt-playground` image and starts web, worker and scheduler. The worker and scheduler could use a simpler image with only redis-tasks, but since we already have the image with all it is easier to reuse that.